### PR TITLE
Fix for IntelliJ 2019

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.intellij" version "0.3.12"
+    id "org.jetbrains.intellij" version "0.4.10"
     id 'net.ltgt.apt' version '0.15'
 }
 
@@ -9,13 +9,14 @@ apply plugin: 'java'
 apply plugin: "net.ltgt.apt"
 
 intellij {
-    version '2018.3'
-    plugins = ['coverage', 'gradle']
     pluginName 'IntelliJ-jME-Plugin'
+    plugins = ['coverage', 'gradle', 'java'] /* java is needed due to restructuring of the IntelliJ API in 2019 */
 }
 
-group 'com.ss.jme.plugin'
-version '1.3.5'
+patchPluginXml {
+    version '1.3.6'
+    sinceBuild '191'
+}
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/com/ss/jme/plugin/JmeModuleComponent.java
+++ b/src/main/java/com/ss/jme/plugin/JmeModuleComponent.java
@@ -1,6 +1,5 @@
 package com.ss.jme.plugin;
 
-import static org.jetbrains.jps.model.java.JavaResourceRootType.RESOURCE;
 import com.intellij.compiler.server.BuildManagerListener;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleComponent;
@@ -21,6 +20,8 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
+
+import static org.jetbrains.jps.model.java.JavaResourceRootType.RESOURCE;
 
 /**
  * The module level component of jME Plugin.
@@ -105,10 +106,11 @@ public class JmeModuleComponent implements ModuleComponent, BuildManagerListener
      * @return the prepared library path
      */
     private @NotNull String prepareLibraryPath(@NotNull String path) {
+        final String substring = path.substring(0, path.length() - 2);
         if (path.endsWith("!/")) {
-            return path.substring(0, path.length() - 2);
+            return substring;
         } else if (path.endsWith("!\\")) {
-            return path.substring(0, path.length() - 2);
+            return substring;
         } else {
             return path;
         }

--- a/src/main/java/com/ss/jme/plugin/JmePluginComponent.java
+++ b/src/main/java/com/ss/jme/plugin/JmePluginComponent.java
@@ -1,7 +1,9 @@
 package com.ss.jme.plugin;
 
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.*;
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -11,10 +13,10 @@ import org.jetbrains.annotations.Nullable;
  * @author JavaSaBr
  */
 @State(name = "JmePluginComponent", storages = @Storage(value = "jme.plugin.xml"))
-public class JmePluginComponent implements ApplicationComponent, PersistentStateComponent<JmePluginState> {
+public class JmePluginComponent implements PersistentStateComponent<JmePluginState> {
 
     public static @NotNull JmePluginComponent getInstance() {
-        return ApplicationManager.getApplication().getComponent(JmePluginComponent.class);
+        return ServiceManager.getService(JmePluginComponent.class);
     }
 
     @NotNull
@@ -22,14 +24,6 @@ public class JmePluginComponent implements ApplicationComponent, PersistentState
 
     public JmePluginComponent() {
         this.state = new JmePluginState();
-    }
-
-    @Override
-    public void initComponent() {
-    }
-
-    @Override
-    public void disposeComponent() {
     }
 
     @Override

--- a/src/main/java/com/ss/jme/plugin/JmePluginState.java
+++ b/src/main/java/com/ss/jme/plugin/JmePluginState.java
@@ -47,4 +47,9 @@ public class JmePluginState {
     public void setJmbPath(@Nullable String jmbPath) {
         this.jmbPath = jmbPath == null ? DEFAULT_JMB_PATH : jmbPath;
     }
+
+    @NotNull
+    public String getJmbPath() {
+        return jmbPath;
+    }
 }

--- a/src/main/java/com/ss/jme/plugin/ui/settings/JmeExternalSettingsPage.java
+++ b/src/main/java/com/ss/jme/plugin/ui/settings/JmeExternalSettingsPage.java
@@ -34,28 +34,33 @@ import java.util.Optional;
 public class JmeExternalSettingsPage implements Configurable, Configurable.NoScroll {
 
     /**
+     * The settings panel.
+     */
+    @Nullable
+    private JmeConfigurablePanel settingsPanel;
+
+    /**
+     * Constructor needs to be public to work with the EP
+     */
+    public JmeExternalSettingsPage() {
+    }
+
+    /**
      * Creates a file chooser descriptor to select an executable file of jMB.
      *
      * @return the file chooser descriptor.
      */
-    public static @NotNull FileChooserDescriptor createJmbDescriptor() {
+    public static @NotNull
+    FileChooserDescriptor createJmbDescriptor() {
         FileChooserDescriptor descriptor = FileChooserDescriptorFactory.createSingleFileDescriptor();
         descriptor.setTitle(JmeMessagesBundle.message("jme.settings.pathToJmb.file.chooser.title"));
         descriptor.setDescription(JmeMessagesBundle.message("jme.settings.pathToJmb.file.chooser.description"));
         return descriptor;
     }
 
-    /**
-     * The settings panel.
-     */
-    @Nullable
-    private JmeConfigurablePanel settingsPanel;
-
-    private JmeExternalSettingsPage() {
-    }
-
     @Override
-    public @Nullable JComponent createComponent() {
+    public @Nullable
+    JComponent createComponent() {
         settingsPanel = new JmeConfigurablePanel();
         return settingsPanel.panel;
     }
@@ -86,7 +91,8 @@ public class JmeExternalSettingsPage implements Configurable, Configurable.NoScr
      *
      * @return the settings panel.
      */
-    private @NotNull Optional<JmeConfigurablePanel> getSettingsPanel() {
+    private @NotNull
+    Optional<JmeConfigurablePanel> getSettingsPanel() {
         return Optional.ofNullable(settingsPanel);
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,14 +10,15 @@
     ]]></description>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="181"/>
+    <idea-version since-build="191"/>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
     <!-- uncomment to enable plugin in all products
     -->
-    <depends>org.jetbrains.plugins.gradle</depends>
+    <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.java</depends>
+    <depends>org.jetbrains.plugins.gradle</depends>
 
     <resource-bundle>messages.jme</resource-bundle>
 
@@ -30,6 +31,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <applicationConfigurable id="com.ss.jme.settings.page"
                 instance="com.ss.jme.plugin.ui.settings.JmeExternalSettingsPage" groupId="language"/>
+        <applicationService serviceImplementation="com.ss.jme.plugin.JmePluginComponent"/>
     </extensions>
 
     <actions>
@@ -40,12 +42,6 @@
                     icon="/com/ss/jme/plugin/ui/icons/jmb.png" />
         </group>
     </actions>
-
-    <application-components>
-        <component>
-            <implementation-class>com.ss.jme.plugin.JmePluginComponent</implementation-class>
-        </component>
-    </application-components>
     <module-components>
         <component>
             <implementation-class>com.ss.jme.plugin.JmeModuleComponent</implementation-class>


### PR DESCRIPTION
- Fix dependency on Java plugin which is now separated in the IntelliJ API
- Persistent settings as Service instead of a component that is initialized always
- Constructor of settings page must be public to work

Please review these changes carefully, because I started this night with a YouTube video of jMonkeyEngine, have never done anything in it, and ended up fixing this plugin..